### PR TITLE
Replace SqlConnection with MySqlConnection

### DIFF
--- a/WebdevPeriod3/Services/BaseRepository.cs
+++ b/WebdevPeriod3/Services/BaseRepository.cs
@@ -66,7 +66,7 @@ namespace WebdevPeriod3.Services
         {
             try
             {
-                await using (var connection = new SqlConnection(_connectionString))
+                await using (var connection = new MySqlConnection(_connectionString))
                 {
                     await connection.OpenAsync();
                     var data = await getData(connection);


### PR DESCRIPTION
This pull request fixes a bug in `BaseRepository` in which the `SqlConnection` class was being used, as opposed to the `MySqlConnection` class.