### PR TITLE
Remove extraneous profile features

### DIFF
--- a/WebdevPeriod3/Areas/Identity/Views/Profile/Index.cshtml
+++ b/WebdevPeriod3/Areas/Identity/Views/Profile/Index.cshtml
@@ -13,12 +13,6 @@
                          alt="">
                 </div>
                 <h1 class="text-gray-900 font-bold text-xl leading-8 my-1">Angy bot-1337</h1>
-                <h3 class="text-gray-600 font-lg text-semibold leading-6">Metally boi who liks to pew pew.</h3>
-                <p class="text-sm text-gray-500 hover:text-gray-600 leading-6">
-                    Lorem ipsum dolor sit amet
-                    consectetur adipisicing elit.
-                    Reprehenderit, eligendi dolorum sequi illum qui unde aspernatur non deserunt
-                </p>
             </div>
             @*<div class="bg-white p-3 border-t-2 border-gray-300">
                 </div>*@

--- a/WebdevPeriod3/Areas/Identity/Views/Profile/Index.cshtml
+++ b/WebdevPeriod3/Areas/Identity/Views/Profile/Index.cshtml
@@ -19,18 +19,6 @@
                     consectetur adipisicing elit.
                     Reprehenderit, eligendi dolorum sequi illum qui unde aspernatur non deserunt
                 </p>
-                <ul class="bg-gray-100 text-gray-600 hover:text-gray-700 hover:shadow py-2 px-3 mt-3 divide-y rounded shadow-sm">
-                    <li class="flex items-center py-3">
-                        <span>Status</span>
-                        <span class="ml-auto">
-                            <span class="bg-green-500 py-1 px-2 rounded text-white text-sm">Active</span>
-                        </span>
-                    </li>
-                    <li class="flex items-center py-3">
-                        <span>Member since</span>
-                        <span class="ml-auto">Nov 07, 2016</span>
-                    </li>
-                </ul>
             </div>
             @*<div class="bg-white p-3 border-t-2 border-gray-300">
                 </div>*@


### PR DESCRIPTION
This pull request resolves #21 by removing the status and description sections from the profile page.
# Before
![image](https://user-images.githubusercontent.com/12574444/110210024-f4f43400-7e8f-11eb-8d04-e89f7c3b831a.png)
# After
![image](https://user-images.githubusercontent.com/12574444/110210010-e3ab2780-7e8f-11eb-9b0e-f2f8cd62b696.png)
