### PR TITLE
Add a default value to SubSystems

### DIFF
--- a/WebdevPeriod3/Models/ProductDto.cs
+++ b/WebdevPeriod3/Models/ProductDto.cs
@@ -10,7 +10,7 @@ namespace WebdevPeriod3.Models
 	{
 		[Required(AllowEmptyStrings = false)]
 		public string Name { get; set; }
-		public List<string> SubSystems { get; set; }
+		public List<string> SubSystems { get; set; } = new List<string>();
 		public string Description { get; set; }
 		[Required]
 		public bool TermsGDPR { get; set; }


### PR DESCRIPTION
This patch fixes #25 by making it so the model never receives `null` as the value of `SubSystems`.