### PR TITLE
Make the dashboard link in the navigation absolute

### DIFF
--- a/WebdevPeriod3/Views/Shared/_Navigation.cshtml
+++ b/WebdevPeriod3/Views/Shared/_Navigation.cshtml
@@ -12,7 +12,7 @@
 
     <!--Link to the dashboard-->
     <li class="mr-1">
-        <a asp-controller="Dashboard" asp-action="Index" class="inline-block p-3 text-gray-300 hover:text-gray-100">Dashboard</a>
+        <a asp-area="" asp-controller="Dashboard" asp-action="Index" class="inline-block p-3 text-gray-300 hover:text-gray-100">Dashboard</a>
     </li>
     <!--Link to the login page-->
     <li class="mr-1">


### PR DESCRIPTION
This patch resolves #27 by specifying the area for the dashboard link in the navigation partial.