### PR TITLE
Improve the registration link

### DIFF
--- a/WebdevPeriod3/Areas/Identity/Views/Login/Index.cshtml
+++ b/WebdevPeriod3/Areas/Identity/Views/Login/Index.cshtml
@@ -71,7 +71,7 @@
             </form>
         </div>
         <div class="flex justify-center items-center mt-6">
-            <a asp-area="Identity" asp-controller="Registration" asp-action="Index" asp-route-returnUrl="@Model.ReturnUrl" target="_blank" class="inline-flex items-center font-bold text-blue-500 hover:text-blue-700 text-xs text-center">
+            <a asp-area="Identity" asp-controller="Registration" asp-action="Index" asp-route-returnUrl="@Model.ReturnUrl" class="inline-flex items-center font-bold text-blue-500 hover:text-blue-700 text-xs text-center">
                 <span>
                     <svg class="h-6 w-6" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" stroke="currentColor">
                         <path d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />

--- a/WebdevPeriod3/Areas/Identity/Views/Login/Index.cshtml
+++ b/WebdevPeriod3/Areas/Identity/Views/Login/Index.cshtml
@@ -71,14 +71,14 @@
             </form>
         </div>
         <div class="flex justify-center items-center mt-6">
-            <a href="#" target="_blank" class="inline-flex items-center font-bold text-blue-500 hover:text-blue-700 text-xs text-center">
+            <a asp-area="Identity" asp-controller="Registration" asp-action="Index" asp-route-returnUrl="@Model.ReturnUrl" target="_blank" class="inline-flex items-center font-bold text-blue-500 hover:text-blue-700 text-xs text-center">
                 <span>
                     <svg class="h-6 w-6" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" stroke="currentColor">
                         <path d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
                     </svg>
                 </span>
                 <span class="ml-2">
-                    <a class="text-blue-700" asp-area="Identity" asp-controller="Registration" asp-action="Index" asp-route-returnUrl="@Model.ReturnUrl">You don't have an account?</a>
+                    You don't have an account?
                 </span>
             </a>
         </div>


### PR DESCRIPTION
This patch fixes #37 by removing the nested links from the registration link. This has improved the accesibility, as our login page now passes the following Lighthouse audit;
![A Lighthouse audit passing](https://user-images.githubusercontent.com/12574444/110493500-f4a7a300-80f2-11eb-8f38-103d3179e4fb.png)
